### PR TITLE
Fix #55: toggle switch disappearing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -123,15 +123,17 @@ class FoldEntityRow extends LitElement {
   static get styles() {
     return css`
       #head {
+        --toggle-icon-width: 40px;
         display: flex;
         cursor: pointer;
         align-items: center;
       }
       #head entity-row-maker {
         flex-grow: 1;
+        max-width: calc(100% - var(--toggle-icon-width));
       }
       #head ha-icon {
-        width: 40px;
+        width: var(--toggle-icon-width);
         cursor: pointer
       }
 


### PR DESCRIPTION
The icon seems to shrink to the available space (could be from the `ha-icon` component itself). Reserving the space for it prevents this.