### PR TITLE
Removed unopened rows to reduce memory overhead

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -180,14 +180,15 @@ class FoldEntityRow extends LitElement {
           icon=${this.open ? "mdi:chevron-up" : "mdi:chevron-down"}
         ></ha-icon>
       </div>
-
-      <div
-        id="items"
-        ?open=${this.open}
-        style=${`padding-left: ${this._config.padding}px`}
-      >
-        ${this.rows}
-      </div>
+      ${this.open
+        ? html` <div
+            id="items"
+            ?open=${this.open}
+            style=${`padding-left: ${this._config.padding}px`}
+          >
+            ${this.rows}
+          </div>`
+        : html``}
     `;
   }
 


### PR DESCRIPTION
I am using the fold-entity-row heavily in one of my dashboards and most of the time the rows are folded. With this fix I reduced the memory overhead by 300MB on my dashboard and I am hoping others will profit from it as well.
All it does is not add the row cards to the DOM unless you actually fold it down.