### PR TITLE
fix: Prefer head: over entity:

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ class FoldEntityRow extends LitElement {
   }
 
   async _finishSetup() {
-    let head = ensureObject(this._config.entity || this._config.head);
+    let head = ensureObject(this._config.head || this._config.entity);
     if (!head) {
       throw new Error("No fold head specified");
     }


### PR DESCRIPTION
When both entity: and head: are included, entity: will supersede head:. Some components (like auto-entities) will automatically set entity: and so any head: options will get ignored.

Use case:
```
type: custom:auto-entities
card:
  type: entities
filter:
  include:
    - group: light.downstairs
      options:
        type: custom:fold-entity-row
        head:
          entity: this.entity_id
          secondary_info: last-changed
```

Fixes #230 